### PR TITLE
Fix crash when itemInfo is nil

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -146,11 +146,6 @@ local function AddItem(source, item, amount, slot, info, created)
 	local totalWeight = GetTotalWeight(Player.PlayerData.items)
 	local itemInfo = QBCore.Shared.Items[item:lower()]
 	local time = os.time()
-	if not created then
-		itemInfo['created'] = time
-	else
-		itemInfo['created'] = created
-	end
 	if not itemInfo and not Player.Offline then
 		QBCore.Functions.Notify(source, "Item does not exist", 'error')
 		return false


### PR DESCRIPTION
When `itemInfo` is `nil`, a crash can occur when trying to set the `created` index.

This code block is not necessary, since a little bit further down, we are setting `created` anyway and this is after `itemInfo` is verified not to be `nil`:

```lua
itemInfo['created'] = created or time
```