### PR TITLE
Add item to trunk export

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -681,7 +681,7 @@ local function FindEmptyTrunkSlot(items, vehicleName, vehicleClass)
     return nil
 end
 
-local function AddToTrunk(plate, slot, fromslot, itemName, amount, info, created, vehicleName, vehicleClass)
+local function AddToTrunk(plate, slot, otherslot, itemName, amount, info, created, vehicleName, vehicleClass)
 	if not Trunks[plate] then 
 		Trunks[plate] = {}
 		Trunks[plate].items = {}
@@ -726,7 +726,7 @@ local function AddToTrunk(plate, slot, fromslot, itemName, amount, info, created
 	else
 		if Trunks[plate].items[slot] and Trunks[plate].items[slot].name == itemName then
 			local itemInfo = QBCore.Shared.Items[itemName:lower()]
-			Trunks[plate].items[fromslot] = {
+			Trunks[plate].items[otherslot] = {
 				name = itemInfo["name"],
 				amount = amount,
 				info = info or "",
@@ -738,7 +738,7 @@ local function AddToTrunk(plate, slot, fromslot, itemName, amount, info, created
 				useable = itemInfo["useable"],
 				image = itemInfo["image"],
 				created = created,
-				slot = fromslot,
+				slot = otherslot,
 			}
 		else
 			local itemInfo = QBCore.Shared.Items[itemName:lower()]

--- a/server/main.lua
+++ b/server/main.lua
@@ -688,16 +688,15 @@ local function AddToTrunk(plate, slot, otherslot, itemName, amount, info, create
 		Trunks[plate].isOpen = false
 		Trunks[plate].label = "Trunk-" .. plate
 	end
+	
 	if not slot then slot = FindEmptyTrunkSlot(Trunks[plate].items, vehicleName, vehicleClass) end
 	amount = tonumber(amount) or 1
+	
 	local itemInfo = QBCore.Shared.Items[itemName:lower()]
 	local time = os.time()
- if not created then 
-			itemInfo['created'] = time
-	else 
-			itemInfo['created'] = created
- end
-	info = info or {}
+	itemInfo['created'] = created or time
+	
+ info = info or {}
 	local ItemData = QBCore.Shared.Items[itemName]
 
 	if not ItemData.unique then

--- a/server/main.lua
+++ b/server/main.lua
@@ -703,10 +703,10 @@ local function AddToTrunk(plate, slot, fromslot, itemName, amount, info, created
     itemInfo['created'] = created or time
 	local ItemData = QBCore.Shared.Items[itemName]
 
-	if not ItemData.unique then -- if not unique
+	if not ItemData.unique then
 		if Trunks[plate].items[slot] and Trunks[plate].items[slot].name == itemName then -- if already occupied, add amount
 			Trunks[plate].items[slot].amount = Trunks[plate].items[slot].amount + amount
-		else -- if not occupied, create new item
+		else
 			local itemInfo = QBCore.Shared.Items[itemName:lower()]
 			Trunks[plate].items[slot] = {
 				name = itemInfo["name"],
@@ -723,8 +723,8 @@ local function AddToTrunk(plate, slot, fromslot, itemName, amount, info, created
 				slot = slot,
 			}
 		end
-	else -- if item is unique
-		if Trunks[plate].items[slot] and Trunks[plate].items[slot].name == itemName then -- if occupied, return to original slot
+	else
+		if Trunks[plate].items[slot] and Trunks[plate].items[slot].name == itemName then
 			local itemInfo = QBCore.Shared.Items[itemName:lower()]
 			Trunks[plate].items[fromslot] = {
 				name = itemInfo["name"],
@@ -740,7 +740,7 @@ local function AddToTrunk(plate, slot, fromslot, itemName, amount, info, created
 				created = created,
 				slot = fromslot,
 			}
-		else -- if free, add to slot
+		else
 			local itemInfo = QBCore.Shared.Items[itemName:lower()]
 			Trunks[plate].items[slot] = {
 				name = itemInfo["name"],

--- a/server/main.lua
+++ b/server/main.lua
@@ -688,23 +688,20 @@ local function AddToTrunk(plate, slot, otherslot, itemName, amount, info, create
 		Trunks[plate].isOpen = false
 		Trunks[plate].label = "Trunk-" .. plate
 	end
-	if not slot then
-		slot = FindEmptyTrunkSlot(Trunks[plate].items, vehicleName, vehicleClass)
-	end
+	if not slot then slot = FindEmptyTrunkSlot(Trunks[plate].items, vehicleName, vehicleClass) end
 	amount = tonumber(amount) or 1
 	local itemInfo = QBCore.Shared.Items[itemName:lower()]
 	local time = os.time()
-    if not created then
-        itemInfo['created'] = os.time()
-    else
-        itemInfo['created'] = created
-    end
+ if not created then 
+			itemInfo['created'] = time
+	else 
+			itemInfo['created'] = created
+ end
 	info = info or {}
-    itemInfo['created'] = created or time
 	local ItemData = QBCore.Shared.Items[itemName]
 
 	if not ItemData.unique then
-		if Trunks[plate].items[slot] and Trunks[plate].items[slot].name == itemName then -- if already occupied, add amount
+		if Trunks[plate].items[slot] and Trunks[plate].items[slot].name == itemName then 
 			Trunks[plate].items[slot].amount = Trunks[plate].items[slot].amount + amount
 		else
 			local itemInfo = QBCore.Shared.Items[itemName:lower()]


### PR DESCRIPTION
**Additions**

- A function to find empty trunk slots, counts the number of slots first via vehiclename, then class then reverts to default
- Export to add item to trunk
- Export to remove items from trunk

**Modifications**

- Modifies the AddToTrunk function, adding the vehicleName and vehicleClass (purpose is for finding out how many slots there are, maybe there's a better way to do this). There is error handling for where the trunk isn't registered already. 

**Testing**
Tested both exports on qbcore, tested to make sure items still worked when adding/removing etc. No bugs found.

**Examples**
            exports['ps-inventory']:AddToTrunk(plate, false, false, "weapon_pistol", 1, info, false, "asea", 2)
            exports['ps-inventory']:AddToTrunk(plate, 1, false, "weapon_pistol", 1, info, false, "asea", 2)
            exports['ps-inventory']:RemoveFromTrunk(plate, 1, "weapon_pistol", false)
