### PR TITLE
Edit the readme shared.lua section for new-qb-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ You need to add a decay value for all items in your `qb-core/shared/items.lua` f
 ```lua
 -- decay = The number of days it takes for an item to decay
 -- delete = If set to true, the item will be removed once it decays
-["decay"] = 28.0, ["delete"] = true
+decay = 28.0, delete = true
 ```
 
 #### Example with the full item in QB-Core's shared file
 
 ```lua
-['sandwich'] = {['name'] = 'sandwich', ['label'] = 'Sandwich', ['weight'] = 200, ['type'] = 'item', ['image'] = 'sandwich.png', ['unique'] = false, ['useable'] = true, ['shouldClose'] = true,	['combinable'] = nil, ['description'] = 'Nice bread for your stomach', ["decay"] = 3.0, ["delete"] = true},
+sandwich = {name = 'sandwich', label = 'Sandwich', weight = 200, type = 'item', image = 'sandwich.png', unique = false, useable = true, shouldClose = true,	combinable = nil, description = 'Nice bread for your stomach', decay = 3.0, delete = true},
 ```
 
 In this example, the sandwich item would take 3 days to decay and once it does, it would be removed.


### PR DESCRIPTION
This edit doesn't need to be tested.
Just noticed that it was using the old qb-core.